### PR TITLE
awareness and cta for axolo

### DIFF
--- a/data/p/developer-experience-survey-template.mdx
+++ b/data/p/developer-experience-survey-template.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Developer experience survey template to improve your engineering processes"
 date: "2022-05-24"
+lastmod: "2023-07-04"
 tags: ["software development", "code review", "template"]
 draft: false
 summary: "This article aims to help companies who want to survey their engineers to improve the developer experience in their engineering team. We developed this survey upon the recommendations of the SPACE framework, the four key DevOps metrics from Accelerate, and our own experience working with engineering teams through Axolo."

--- a/data/p/developer-experience-survey-template.mdx
+++ b/data/p/developer-experience-survey-template.mdx
@@ -7,6 +7,10 @@ summary: "This article aims to help companies who want to survey their engineers
 image: "/blog/static/images/productivity/developer_experience_survey.jpg"
 ---
 
+Welcome to this template of a developer experience survey! We hope you'll find what you are looking for, and if you're interested in the best way to manage your pull requests in Slack, you should take a look at <a href="https://axolo.co" className="no-underline !text-gray-300" target="_blank" rel="noopener">Axolo, <span className="rainbow-button">which helps thousands of developers merge pull requests faster</span></a> (also [incubated by Slack in 2023](https://axolo.co/blog/p/axolo-joins-slack-future-of-work-incubator)).
+
+<CTABanner type="learn" />
+
 ## Introduction to the developer experience survey
 
 This article aims to help companies who want to survey their engineers to improve the developer experience in their engineering team. We developed this survey upon the recommendations of the [SPACE framework](https://axolo.co/blog/p/developer-productivity), the [four key DevOps metrics from Accelerate](https://axolo.co/blog/p/accelerate-four-key-devops-metrics), and our own experience working with engineering teams through [Axolo](https://axolo.co).
@@ -192,4 +196,4 @@ Is there anything you’d like to say that didn’t fit elsewhere?
 
 --
 
-<CTABanner type="dx" />
+<CTABanner type="try" />

--- a/data/p/gitlab-code-review-best-practices.mdx
+++ b/data/p/gitlab-code-review-best-practices.mdx
@@ -1,11 +1,16 @@
 ---
 title: "GitLab code review best practices"
 date: "2022-08-09"
+lastmod: "2023-07-04"
 tags: ["gitlab", "code-review"]
 draft: false
 summary: "In this article, we will be going through the code review best practices in GitLab. If you are interesting in learning how to use GitLab to be more productive while reviewing code, follow us!"
 image: "/blog/static/images/gitlab/gitlab_code_review_best_practices.jpg"
 ---
+
+Welcome to this guide on GitLab code review best practices!We hope you'll find this guide useful, and if you're interested in the best way to manage your merge requests in GitLab, you should take a look at <a href="https://axolo.co" className="no-underline !text-gray-300"  target="_blank" rel="noopener">Axolo, <span className="rainbow-button">which helps thousands of developers review merge requests faster in Slack</span></a> (also [incubated by Slack in 2023](https://axolo.co/blog/p/axolo-joins-slack-future-of-work-incubator)).
+
+<br />
 
 <TOCInline toc={props.toc} toHeading={3} asDisclosure />
 
@@ -178,6 +183,8 @@ Developers can begin collecting feedback much sooner. Submit a merge request and
 #### GitLab review apps for the design, product, and marketing team
 
 Giving feedback to designers, product managers, marketing colleagues, and others has never been easier. To preview changes, you won't need to check out branches or set up a staging environment. With Review Apps, you can see the live changes by clicking a link. Hopefully, this means you'll be able to provide more timely and accurate feedback.
+
+<CTABanner type="try" tool="gitlab" />
 
 ## 3. GitLab CI/CD & automatic deployment
 

--- a/data/p/part-3-github-pull-request-template.mdx
+++ b/data/p/part-3-github-pull-request-template.mdx
@@ -8,7 +8,7 @@ summary: "Pull request templates allow your organizations to have a default text
 image: "/blog/static/images/pull-request-guide/github-pr-template.png"
 ---
 
-Welcome to this guide on GitHub pull request templates! We hope you'll find what you are looking for, and if you're interested in the best way to manage your pull requests in Slack, you should take a look at <a href="https://axolo.co" className="no-underline !text-gray-300">Axolo, <span className="rainbow-button">which helps thousands of developers merge pull requests faster</span></a> (also [incubated by Slack in 2023](https://axolo.co/blog/p/axolo-joins-slack-future-of-work-incubator)).
+Welcome to this guide on GitHub pull request templates! We hope you'll find what you are looking for, and if you're interested in the best way to manage your pull requests in Slack, you should take a look at <a href="https://axolo.co" className="no-underline !text-gray-300" target="_blank" rel="noopener">Axolo, <span className="rainbow-button">which helps thousands of developers merge pull requests faster</span></a> (also [incubated by Slack in 2023](https://axolo.co/blog/p/axolo-joins-slack-future-of-work-incubator)).
 
 <CTABanner type="learn" />
 


### PR DESCRIPTION
J'ai pris deux articles là où on a un peu de traffic bien ciblé, mais où on met pas assez en avant Axolo au début/fin. Je pense quand forçant pas les users mais en disant "c'est nous qui vous offrons le contenu, voici comment on peut vous aider", on pourrait avoir une chance d'avoir un clic ou au moins un peu plus d'awareness 

![image](https://github.com/axolo-co/blog.axolo/assets/57633651/9c60fb33-ff5e-4f8c-a0b2-6007d9290417)


![image](https://github.com/axolo-co/blog.axolo/assets/57633651/0d2cd9f2-1a2c-44b1-b871-ca4fef345ccd)
